### PR TITLE
Remplacement du HUB de templates par la marketplace de templates (plus complet)

### DIFF
--- a/ci-cd/README.md
+++ b/ci-cd/README.md
@@ -48,7 +48,7 @@
 * [Optimiser la durée de vos pipelines avec les DAG](https://blog.stephane-robert.info/post/dag-needs-gitlab-ci/)
 * [Créer des releases](https://blog.stephane-robert.info/post/gitlab-ci-release/)
 * [Comment tester un rôle Ansible avec Molecule ?](https://connect.ed-diamond.com/linux-pratique/lp-128/comment-tester-un-role-ansible-avec-molecule)
-* [Hub de template de pipeline CICD](https://gitlab.com/r2devops/hub)
+* [Marketplace de templates CICD GitLab](https://r2devops.io/marketplace)
 
 ###  1.5. <a name='Vidos'></a>Vidéos
 


### PR DESCRIPTION
Remplacement du lien vers le HUB de templates R2 open source par le lien vers la marketplace. La marketplace rassemble tous les templates open source de la communauté.

<!-- Veuillez remplir les champs **gras**, soumettre la demande de pull request. NE RIEN SOUMETTRE SI VOUS ÉCHOUEZ À L'UNE DE CES RÈGLES -->

**[Insérez vos liens ICI.]**
- https://r2devops.io/marketplace

**[Dîtes en quelques mots pourquoi elle devrait être ajouté ici.]**
Le lien de la marketplace est plus complet que le lien précedent (HUB R2Devops uniquement)

# En soumettant cette pull request, je confirme avoir lu et respecté les exigences ci-dessous.

Ne pas le faire correctement entraînera simplement la fermeture de cette demande
et la perte de temps pour tout le monde.

- [x] J'ai lu et compris les [directives de contribution](https://github.com/stephrobert/awesome-french-devops/blob/main/README.md#10-contribuer)
- [x] Le contenu du ou des liens sont écrits en Francais. Exception faire des
  URL des sites officiels des produits Devops.
- [x] Le(s) lien(s) que j'ai ajouté **n'est pas à but commerciale**. Par exemple
  ne renvoie pas vers un formulaire de contact pour télécharger un livre blanc
  ou des ressources payantes.
- [x] Le(s) lien(s)que j'ai ajoutée n'est pas un doublon.
- [x] Cette pull request a un titre descriptif. Par exemple, `Ajout du site https://site.fr`, pas `Maj de` ou `Ajout`.
- [x] J'ai écris en Markdown.
