### PR TITLE
Ajout de la chaine YT DevOps D-DAY

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ faire ma veille techno. Je la mettrai à jour régulièrement. [feedly.opml](./f
 * [Cloud Nord](https://www.youtube.com/@cloudnord6827)
 * [DevoxxFR](https://youtube.com/@DevoxxFRvideos)
 * [KCD France](https://www.youtube.com/@KubernetesCommunityDaysFr)
+* [DevOps D-DAY](https://www.youtube.com/@devopsdday)
 
 ## 14. <a name='Contribuer'></a>Contribuer
 


### PR DESCRIPTION
- [Chaine Youtube DevOps D-DAY](https://www.youtube.com/@devopsdday)

La chaine YouTube de la conférence DevOps D-DAY propose des rediffusions de talks. Je pense que ça a sa place dans ce dépôt :smiley: 

# En soumettant cette pull request, je confirme avoir lu et respecté les exigences ci-dessous.

Ne pas le faire correctement entraînera simplement la fermeture de cette demande
et la perte de temps pour tout le monde.

- [x] J'ai lu et compris les [directives de contribution](https://github.com/stephrobert/awesome-french-devops/blob/main/README.md#10-contribuer)
- [x] Le contenu du ou des liens sont écrits en Francais. Exception faire des
  URL des sites officiels des produits Devops.
- [x] Le(s) lien(s) que j'ai ajouté **n'est pas à but commerciale**. Par exemple
  ne renvoie pas vers un formulaire de contact pour télécharger un livre blanc
  ou des ressources payantes.
- [x] Le(s) lien(s)que j'ai ajoutée n'est pas un doublon.
- [x] Cette pull request a un titre descriptif. Par exemple, `Ajout du site https://site.fr`, pas `Maj de` ou `Ajout`.
- [x] J'ai écris en Markdown.
